### PR TITLE
Remove margin from systopic button

### DIFF
--- a/src/main/java/org/correomqtt/plugin/systopic/controller/SysTopicButtonController.java
+++ b/src/main/java/org/correomqtt/plugin/systopic/controller/SysTopicButtonController.java
@@ -1,7 +1,6 @@
 package org.correomqtt.plugin.systopic.controller;
 import javafx.application.Platform;
 import javafx.fxml.FXML;
-import javafx.geometry.Insets;
 import javafx.scene.control.Button;
 import javafx.scene.layout.HBox;
 import org.correomqtt.business.dispatcher.ConnectionLifecycleDispatcher;
@@ -28,7 +27,6 @@ public class SysTopicButtonController  implements ConnectionLifecycleObserver {
     }
 
     public void addItems(HBox toolbar, int indexToinsert) {
-        HBox.setMargin(SYSbutton, new Insets(0, 0, 0, 5));
         toolbar.getChildren().add(indexToinsert,SYSbutton);
     }
 


### PR DESCRIPTION
This removes the margin on the left side of the systopic button. It is not needed anymore, because the button group on the left side is removed via https://github.com/EXXETA/correomqtt/pull/61:

Before: 
![grafik](https://user-images.githubusercontent.com/25148277/110235909-1d813a00-7f33-11eb-92e2-83ac6a67fe0f.png)

After:
![grafik](https://user-images.githubusercontent.com/25148277/110235883-f32f7c80-7f32-11eb-98a0-e2378f4c2bcd.png)

